### PR TITLE
Prevent host link-backs

### DIFF
--- a/src/http/get-benefits/index.js
+++ b/src/http/get-benefits/index.js
@@ -5,9 +5,9 @@ const linkDefs = require("./links.json");
 exports.handler = arc.http.async(handler);
 
 async function handler(req) {
-  // Partner comes in via URL query parameter.
-  // We will need this in the weeks to come.
-  // const partner = req.query.partner;
+  // These values comes in via URL query parameter.
+  const host = req.query.host;
+  const language = req.query.language;
 
   try {
     const throttles = [...throttleDefs];
@@ -34,7 +34,7 @@ async function handler(req) {
 
     console.log(throttles);
 
-    const allowedLinks = pickAllowedLinks(throttles, 3);
+    const allowedLinks = pickAllowedLinks(throttles, host, 3);
     const data = assembleData(allowedLinks);
 
     return {
@@ -45,7 +45,7 @@ async function handler(req) {
     // error occurred trying to lookup throttles
     console.log(e);
 
-    const randomLinks = pickRandom(linkDefs.links, 3);
+    const randomLinks = pickRandomLinks(linkDefs.links, host, 3);
     const data = assembleData(randomLinks);
 
     // return default info
@@ -56,15 +56,16 @@ async function handler(req) {
   }
 }
 
-function pickRandom(array, n = 3) {
-  return array
-    .map((value) => ({ value, sort: Math.random() }))
+function pickRandomLinks(links, host, n = 3) {
+  return links
+    .filter((link) => link.key !== host)
+    .map((link) => ({ link, sort: Math.random() }))
     .sort((a, b) => a.sort - b.sort)
-    .map(({ value }) => value)
+    .map(({ link }) => link)
     .slice(0, n);
 }
 
-function pickAllowedLinks(throttles, n) {
+function pickAllowedLinks(throttles, host, n) {
   const links = { ...linkDefs };
 
   const data = links.links.reduce((bucket, link) => {
@@ -76,7 +77,7 @@ function pickAllowedLinks(throttles, n) {
     return bucket;
   }, []);
 
-  return pickRandom(data, n);
+  return pickRandomLinks(data, host, n);
 }
 
 function assembleData(links) {

--- a/tests/http-test.js
+++ b/tests/http-test.js
@@ -1,84 +1,117 @@
-const test = require('tape');
-const tiny = require('tiny-json-http');
-const sandbox = require('@architect/sandbox');
-let arc = require('@architect/functions');
-const targetServer = 'http://localhost:3333';
+const test = require("tape");
+const tiny = require("tiny-json-http");
+const sandbox = require("@architect/sandbox");
+let arc = require("@architect/functions");
+const targetServer = "http://localhost:3333";
 
 /**
  * first we need to start the local http server
  */
-test('sandbox.start', async t=> {
-  t.plan(1)
-  await sandbox.start({ quiet: true })
-  t.ok(true, `sandbox started on ${targetServer}`)
-})
+test("sandbox.start", async (t) => {
+  t.plan(1);
+  await sandbox.start({ quiet: true });
+  t.ok(true, `sandbox started on ${targetServer}`);
+});
 
 /**
  * then we can make a request to it and check the result
  */
-test('get /benefits', async t=> {
-  t.plan(1)
-  let result = await tiny.get({ url: targetServer + "/benefits" })
-  t.ok(result, 'got 200 response')
+test("get /benefits", async (t) => {
+  t.plan(1);
+  let result = await tiny.get({ url: targetServer + "/benefits" });
+  t.ok(result, "got 200 response");
   // console.log(result)
-})
+});
 
-test('post /event', async t=> {
-  t.plan(1)
-  let result = await tiny.post({
-    url: targetServer+'/event',
-    data: {
-      event: 'render',
-      displayURL: 'https://awebsite.ca.gov',
-      userAgent: 'Lynx text only browser',
-      language: 'en-US',
-      link: 'https://wic.ca.gov',
-      linkText: 'Apply to WIC',
+/**
+ * Ensure we don't deliver a link back to the same host.
+ */
+test("get /benefits?host=CALFRESH", async (t) => {
+  t.plan(10);
+
+  // Repeat the test five times.
+  for (i = 0; i < 5; i++) {
+    let result = await tiny.get({
+      url: targetServer + "/benefits?host=CALFRESH",
+    });
+
+    t.ok(result, "got 200 response");
+
+    let links = JSON.parse(result.body).links;
+    let hostLinksFound = links.some((link) => link.key === "CALFRESH");
+
+    if (hostLinksFound) {
+      t.fail("served link back to same host");
+    } else {
+      t.pass("served no links back to same host");
     }
-  })
-  t.ok(result.body.json.hasOwnProperty('event'), 'got event response back')
+  }
+});
+
+test("post /event", async (t) => {
+  t.plan(1);
+  let result = await tiny.post({
+    url: targetServer + "/event",
+    data: {
+      event: "render",
+      displayURL: "https://awebsite.ca.gov",
+      userAgent: "Lynx text only browser",
+      language: "en-US",
+      link: "https://wic.ca.gov",
+      linkText: "Apply to WIC",
+    },
+  });
+  t.ok(result.body.json.hasOwnProperty("event"), "got event response back");
   // console.log(result.body)
-})
+});
 
 // scan and get events
-test('db', async t => {
-  t.plan(1)
-  let data = await arc.tables()
-  let events = await data.events.scan({})
+test("db", async (t) => {
+  t.plan(1);
+  let data = await arc.tables();
+  let events = await data.events.scan({});
   // console.log(events)
-  t.ok(Array.isArray(events.Items), 'found some items')
-})
+  t.ok(Array.isArray(events.Items), "found some items");
+});
 
 // query for events that are in a specific domain
-test('dbquery', async t => {
-  t.plan(1)
-  let data = await arc.tables()
+test("dbquery", async (t) => {
+  t.plan(1);
+  let data = await arc.tables();
   let awebViews = await data.events.query({
-    KeyConditionExpression: "eventKey = :eventKey AND begins_with(displayURL, :displayURL)",
-    ExpressionAttributeValues: { ":eventKey": 'render', ":displayURL": 'https://awebsite.ca.gov' }
-  })
-  console.log(awebViews)
-  t.ok(Array.isArray(awebViews.Items), 'queried some items')
-})
+    KeyConditionExpression:
+      "eventKey = :eventKey AND begins_with(displayURL, :displayURL)",
+    ExpressionAttributeValues: {
+      ":eventKey": "render",
+      ":displayURL": "https://awebsite.ca.gov",
+    },
+  });
+  console.log(awebViews);
+  t.ok(Array.isArray(awebViews.Items), "queried some items");
+});
 
 // count the events
-test('dbquerycount', async t => {
-  t.plan(1)
-  let data = await arc.tables()
+test("dbquerycount", async (t) => {
+  t.plan(1);
+  let data = await arc.tables();
   let awebViews = await data.events.query({
-    KeyConditionExpression: "eventKey = :eventKey AND begins_with(displayURL, :displayURL)",
-    ExpressionAttributeValues: { ":eventKey": 'render', ":displayURL": 'https://awebsite.ca.gov' },
-    Select: "COUNT"
-  })
-  console.log(awebViews)
-  t.ok(awebViews.Count >= 0, 'queried and then counted some items')
-})
+    KeyConditionExpression:
+      "eventKey = :eventKey AND begins_with(displayURL, :displayURL)",
+    ExpressionAttributeValues: {
+      ":eventKey": "render",
+      ":displayURL": "https://awebsite.ca.gov",
+    },
+    Select: "COUNT",
+  });
+  console.log(awebViews);
+  t.ok(awebViews.Count >= 0, "queried and then counted some items");
+});
 
 /**
  * finally close the server so we cleanly exit the test
  */
-test('sandbox.end', async t=> {
-  t.plan(1)
-  await sandbox.end()
-  t.ok(true, 'sandbox ended')
-})
+test("sandbox.end", async (t) => {
+  t.plan(1);
+  await sandbox.end();
+  t.ok(true, "sandbox ended");
+});


### PR DESCRIPTION
Provided a `host` by the client, this PR prevents the API from serving a link back to the host itself.

The client-side mark-up would look like the following. (We already merged support for this into the widget.)

`<cagov-benefits-recs host="CALFRESH"></cagov-benefits-recs>`

This comes to the API as URL query parameters.

`/benefits?host=CALFRESH`

The API then checks this host code against the `key` code of each link in `src/http/get-benefits/links.json`. If a `key`/`host` match is found, that link is excluded from the response.