### PR TITLE
Big refactor for targeting and analytics

### DIFF
--- a/src/http/get-benefits/index.js
+++ b/src/http/get-benefits/index.js
@@ -1,135 +1,26 @@
-let arc = require("@architect/functions");
-const throttleDefs = require("@architect/shared/throttles.json");
-const linkDefs = require("@architect/shared/links.json");
-const icons = require("@architect/shared/icons.js");
+const arc = require("@architect/functions");
+const { assembleLinks } = require("@architect/shared/links");
+const { applyRules } = require("@architect/shared/rules");
 
-exports.handler = arc.http.async(handler);
-
-async function handler(req) {
-  // These values come in via URL query parameter.
-  const host = req.query.host;
+/** Core function for get-benefits. */
+exports.handler = arc.http.async(async (req) => {
+  const host = decodeURIComponent(req.query.host || "");
   const language = req.query.language || "en";
 
-  const links = assembleLinks(language);
-
-  try {
-    const throttles = [...throttleDefs];
-
-    const day = new Date().toISOString().split("T")[0].toString();
-    const dynamo = await arc.tables();
-
-    const promises = [];
-
-    // Check each throttle to see if we've reached the limit.
-    // Add current stats to each throttle object.
-    throttles.forEach(async (throttle) => {
-      const name = throttle.name;
-
-      // If the throttle is already set to zero, we don't need to check DynamoDB.
-      if (throttle.limit === 0) {
-        throttle.count = 0;
-        throttle.exceeded = true;
-      } else {
-        const promise = dynamo.throttleclicks
-          .get({ name, day })
-          .then((response) => {
-            const count = response?.hits || 0;
-            throttle.count = count;
-            throttle.exceeded = count >= throttle.limit;
-            console.log(
-              `Throttle for ${name} on ${day} is at ${count}/${throttle.limit}.`
-            );
-          });
-
-        promises.push(promise);
-      }
-    });
-
-    await Promise.all(promises);
-
-    const allowedLinks = pickAllowedLinks(links, throttles, host, 3);
-    const data = assembleData(allowedLinks);
-
-    return {
-      cors: true,
-      json: JSON.stringify(data),
-    };
-  } catch (e) {
-    console.log(e); // Log the error.
-
-    // Just get random default data.
-    const randomLinks = pickRandomLinks(links, host, 3);
-    const data = assembleData(randomLinks);
-
-    return {
-      cors: true,
-      json: JSON.stringify(data),
-    };
-  }
-}
-
-function pickRandomLinks(links, host, n = 3) {
-  return links
-    .filter((link) => link.key !== host)
-    .map((link) => ({ link, sort: Math.random() }))
-    .sort((a, b) => a.sort - b.sort)
-    .map(({ link }) => link)
-    .slice(0, n);
-}
-
-function pickAllowedLinks(links, throttles, host, n) {
-  const data = links.reduce((bucket, link) => {
-    const blockingThrottles = throttles.filter(
-      (throttle) => throttle.urls.includes(link.url) && throttle.exceeded
-    );
-
-    if (blockingThrottles.length < 1) bucket.push(link);
-    return bucket;
-  }, []);
-
-  return pickRandomLinks(data, host, n);
-}
-
-function assembleData(links) {
-  return {
+  const allLinks = assembleLinks(language, host);
+  console.log("All:" + allLinks.length);
+  const links = await applyRules(allLinks, host);
+  console.log("Filtered:" + links.length);
+  const data = {
     header: "Apply for more benefits!",
     tagline: "You might be able to get:",
     experimentName: "2023-08-01-resume-tracking",
-    experimentVariation: links.map((link) => link.key).join("-"),
+    experimentVariation: links.map((link) => link.id).join("-"),
     links,
   };
-}
 
-function assembleLinks(language = "en") {
-  // Unless it's Chinese, strip the language code down to two characters.
-  // We need to preserve the Chinese code to display Traditional vs. Simplified.
-  const langKey = language.startsWith("zh") ? language : language.slice(0, 2);
-
-  // Return a single set of values for each link, based on language.
-  // Default to English where values are unavailable.
-  const links = Object.keys(linkDefs).map((key) => {
-    const link = linkDefs[key];
-
-    // Get the SVG markup for the icon.
-    const iconKey = link[langKey]?.icon || link.en.icon;
-    const graphic = icons[iconKey];
-
-    const lead = link[langKey]?.lead || link.en.lead || "";
-    const catalyst = link[langKey]?.catalyst || link.en.catalyst || "";
-    const description = link[langKey]?.description || link.en.description || "";
-    const url = link[langKey]?.url || link.en.url || "";
-
-    return {
-      linktext: lead, // linktext depreciated
-      program: catalyst, // program depreciated
-      lead,
-      catalyst,
-      description, // description possibly depreciated
-      url,
-      graphic,
-      key,
-    };
-  });
-
-  return links;
-}
+  return {
+    cors: true,
+    json: JSON.stringify(data),
+  };
+});

--- a/src/http/get-benefits/index.js
+++ b/src/http/get-benefits/index.js
@@ -107,20 +107,27 @@ function assembleLinks(language = "en") {
 
   // Return a single set of values for each link, based on language.
   // Default to English where values are unavailable.
-  const links = Object.keys(linkDefs).map((linkKey) => {
-    const link = linkDefs[linkKey];
+  const links = Object.keys(linkDefs).map((key) => {
+    const link = linkDefs[key];
 
     // Get the SVG markup for the icon.
     const iconKey = link[langKey]?.icon || link.en.icon;
-    const iconGraphic = icons[iconKey];
+    const graphic = icons[iconKey];
+
+    const lead = link[langKey]?.lead || link.en.lead || "";
+    const catalyst = link[langKey]?.catalyst || link.en.catalyst || "";
+    const description = link[langKey]?.description || link.en.description || "";
+    const url = link[langKey]?.url || link.en.url || "";
 
     return {
-      linktext: link[langKey]?.linktext || link.en.linktext,
-      description: link[langKey]?.description || link.en.description,
-      program: link[langKey]?.program || link.en.program,
-      url: link[langKey]?.url || link.en.url,
-      graphic: iconGraphic,
-      key: linkKey,
+      linktext: lead, // linktext depreciated
+      program: catalyst, // program depreciated
+      lead,
+      catalyst,
+      description, // description possibly depreciated
+      url,
+      graphic,
+      key,
     };
   });
 

--- a/src/http/post-event/index.js
+++ b/src/http/post-event/index.js
@@ -1,5 +1,6 @@
 let arc = require("@architect/functions");
 const throttles = require("@architect/shared/throttles.json");
+const url = require("@architect/shared/url");
 
 /**
  * @description Event receiving endpoint for benefits recommendation widget
@@ -55,7 +56,7 @@ exports.handler = async function http(req) {
 
       // find relevant throttle
       const activeThrottles = throttles.filter((throttle) =>
-        throttle.urls.includes(postData.link)
+        url.findMatch(throttle.urls, postData.link)
       );
 
       if (activeThrottles.length < 1) {

--- a/src/shared/hosts.json
+++ b/src/shared/hosts.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "edd_ui_recert",
+    "urls": [
+      "https://uio.edd.ca.gov/UIO/Pages/ExternalUser/Certification/FormCCA4581RegularDUACertificationQuestionsConfirmation.aspx"
+    ]
+  },
+  {
+    "id": "edd_pfl_submit",
+    "urls": [
+      "https://sdio.edd.ca.gov/DIAE/Pages/ExternalUser/InitialClaim/Confirmation.aspx"
+    ]
+  },
+  {
+    "id": "cdph_wic_elig",
+    "urls": ["https://myfamily.wic.ca.gov/Home/AmIEligible"]
+  }
+]

--- a/src/shared/links.js
+++ b/src/shared/links.js
@@ -1,0 +1,96 @@
+const linkDefs = require("./links.json");
+const hostDefs = require("./hosts.json");
+const icons = require("./icons");
+const url = require("./url");
+
+const AnalyticEngines = {
+  GA: "ga",
+  PIWIK: "piwik",
+};
+
+/**
+ * Find the host definition for a given host url.
+ * @param {string} host
+ */
+const findHostDef = (host) => {
+  const pHostUrl = url.parse(host);
+
+  if (pHostUrl) {
+    return hostDefs.find((hostDef) =>
+      hostDef.urls.some((hostDefUrl) => {
+        const pHostDefUrl = url.parse(hostDefUrl);
+        return pHostDefUrl.hostname === pHostUrl.hostname;
+      })
+    );
+  } else {
+    return undefined;
+  }
+};
+
+/**
+ * Add query string parameters for the target site's analytics engine.
+ * @param {string} linkUrl
+ * @param {string} analytics
+ * @param {any} hostDef
+ */
+const addAnalytics = (linkUrl, analytics, hostDef) => {
+  const pUrl = url.parse(linkUrl);
+
+  if (pUrl && hostDef) {
+    if (hostDef && analytics === AnalyticEngines.GA) {
+      pUrl.searchParams.append("utm_source", hostDef.id);
+      pUrl.searchParams.append("utm_medium", "referral");
+      pUrl.searchParams.append("utm_campaign", "odibr");
+    }
+
+    return pUrl.href;
+  } else {
+    return linkUrl;
+  }
+};
+
+/**
+ * Construct link objects for the given language and host.
+ * @param {string} language
+ * @param {string} host
+ * @returns
+ */
+exports.assembleLinks = (language, host) => {
+  // Unless it's Chinese, strip the language code down to two characters.
+  // We need to preserve the Chinese code to display Traditional vs. Simplified.
+  const langKey = language.startsWith("zh") ? language : language.slice(0, 2);
+
+  const hostDef = findHostDef(host);
+
+  // Return a single set of values for each link, based on language.
+  // Default to English where values are unavailable.
+  const links = Object.keys(linkDefs).map((key) => {
+    const link = linkDefs[key];
+
+    // Get the SVG markup for the icon.
+    const iconKey = link[langKey]?.icon || link.en.icon;
+    const graphic = icons[iconKey];
+
+    const lead = link[langKey]?.lead || link.en.lead || "";
+    const catalyst = link[langKey]?.catalyst || link.en.catalyst || "";
+    const description = link[langKey]?.description || link.en.description || "";
+    const linkUrl = link[langKey]?.url || link.en.url || "";
+    const analytics = link[langKey]?.analytics || link.en.analytics || "";
+
+    const urlWithAnalytics = addAnalytics(linkUrl, analytics, hostDef);
+
+    return {
+      linktext: lead, // linktext depreciated
+      program: catalyst, // program depreciated
+      lead,
+      catalyst,
+      description, // description possibly depreciated
+      url: urlWithAnalytics,
+      graphic,
+      language: langKey,
+      id: key,
+    };
+  });
+
+  return links;
+};

--- a/src/shared/links.json
+++ b/src/shared/links.json
@@ -1,63 +1,56 @@
 {
   "EITC": {
     "en": {
-      "linktext": "Tax credits for working",
-      "description": "",
-      "program": "How to file",
+      "lead": "Tax credits for working",
+      "catalyst": "How to file",
       "url": "https://www.ftb.ca.gov/about-ftb/newsroom/caleitc/index.html",
       "icon": "taxBook"
     }
   },
   "WIC": {
     "en": {
-      "linktext": "Cash aid for infant nutrition",
-      "description": "",
-      "program": "How to get WIC",
+      "lead": "Cash aid for infant nutrition",
+      "catalyst": "How to get WIC",
       "url": "https://myfamily.wic.ca.gov/Home/HowCanIGetWIC#HowCanIGetWIC",
       "icon": "familyPeople"
     }
   },
   "ACP": {
     "en": {
-      "linktext": "Up to $30 off high-speed internet",
-      "description": "",
-      "program": "How to apply",
+      "lead": "Up to $30 off high-speed internet",
+      "catalyst": "How to apply",
       "url": "https://broadbandforall.cdt.ca.gov/affordable-connectivity-program/apply-for-acp",
       "icon": "wiFi"
     }
   },
   "CALFRESH": {
     "en": {
-      "linktext": "Money for food",
-      "description": "",
-      "program": "How to apply for CalFresh",
+      "lead": "Money for food",
+      "catalyst": "How to apply for CalFresh",
       "url": "https://www.getcalfresh.org/s/ODIwidget",
       "icon": "foodBasket"
     }
   },
   "CALWORKS": {
     "en": {
-      "linktext": "Cash aid if you have kids",
-      "description": "",
-      "program": "How to apply for CalWORKs",
+      "lead": "Cash aid if you have kids",
+      "catalyst": "How to apply for CalWORKs",
       "url": "https://benefitscal.com/r/cwodiwidgeten",
       "icon": "moneyStack"
     }
   },
   "LIHWAP": {
     "en": {
-      "linktext": "Help paying water bills",
-      "description": "",
-      "program": "How to apply for LIHWAP",
+      "lead": "Help paying water bills",
+      "catalyst": "How to apply for LIHWAP",
       "url": "https://www.csd.ca.gov/Pages/WaterBill.aspx",
       "icon": "waterDrops"
     }
   },
   "LIHEAP": {
     "en": {
-      "linktext": "Help paying energy bills",
-      "description": "",
-      "program": "How to apply for LIHEAP",
+      "lead": "Help paying energy bills",
+      "catalyst": "How to apply for LIHEAP",
       "url": "https://caliheapapply.com",
       "icon": "shock"
     }

--- a/src/shared/links.json
+++ b/src/shared/links.json
@@ -4,7 +4,8 @@
       "lead": "Tax credits for working",
       "catalyst": "How to file",
       "url": "https://www.ftb.ca.gov/about-ftb/newsroom/caleitc/index.html",
-      "icon": "taxBook"
+      "icon": "taxBook",
+      "analytics": "ga"
     }
   },
   "WIC": {
@@ -12,7 +13,8 @@
       "lead": "Cash aid for infant nutrition",
       "catalyst": "How to get WIC",
       "url": "https://myfamily.wic.ca.gov/Home/HowCanIGetWIC#HowCanIGetWIC",
-      "icon": "familyPeople"
+      "icon": "familyPeople",
+      "analytics": "ga"
     }
   },
   "ACP": {
@@ -20,7 +22,8 @@
       "lead": "Up to $30 off high-speed internet",
       "catalyst": "How to apply",
       "url": "https://broadbandforall.cdt.ca.gov/affordable-connectivity-program/apply-for-acp",
-      "icon": "wiFi"
+      "icon": "wiFi",
+      "analytics": "ga"
     }
   },
   "CALFRESH": {
@@ -28,7 +31,8 @@
       "lead": "Money for food",
       "catalyst": "How to apply for CalFresh",
       "url": "https://www.getcalfresh.org/s/ODIwidget",
-      "icon": "foodBasket"
+      "icon": "foodBasket",
+      "analytics": "ga"
     }
   },
   "CALWORKS": {
@@ -36,7 +40,8 @@
       "lead": "Cash aid if you have kids",
       "catalyst": "How to apply for CalWORKs",
       "url": "https://benefitscal.com/r/cwodiwidgeten",
-      "icon": "moneyStack"
+      "icon": "moneyStack",
+      "analytics": "ga"
     }
   },
   "LIHWAP": {
@@ -44,7 +49,8 @@
       "lead": "Help paying water bills",
       "catalyst": "How to apply for LIHWAP",
       "url": "https://www.csd.ca.gov/Pages/WaterBill.aspx",
-      "icon": "waterDrops"
+      "icon": "waterDrops",
+      "analytics": "ga"
     }
   },
   "LIHEAP": {
@@ -52,7 +58,8 @@
       "lead": "Help paying energy bills",
       "catalyst": "How to apply for LIHEAP",
       "url": "https://caliheapapply.com",
-      "icon": "shock"
+      "icon": "shock",
+      "analytics": "ga"
     }
   }
 }

--- a/src/shared/rules.js
+++ b/src/shared/rules.js
@@ -1,0 +1,62 @@
+/**
+ * rules.js
+ * Welcome to rules.
+ * Rules alter which target links go down the wire to the widget.
+ * Each rule is a function.
+ * A rule takes a list of links.
+ * A rule returns a modified list of links.
+ * Rules are processed in a specific order.
+ */
+
+const url = require("./url");
+const { getThrottles } = require("./throttles");
+
+/** Remove links that have exceeded daily throttles. */
+const removeThrottledLinks = (links, { throttles }) =>
+  links.filter((link) => {
+    const blockingThrottles = throttles.filter(
+      (throttle) => url.findMatch(throttle.urls, link.url) && throttle.exceeded
+    );
+
+    // Allow the link if no blocking throttles found.
+    return blockingThrottles.length < 1;
+  });
+
+/** Remove links that point back to the same host site as the widget. */
+const removeLinkBacks = (links, { host }) =>
+  links.filter((link) => !url.matchHosts(host, link.url));
+
+/** Randomize the order of the links. */
+const randomizeOrder = (links) =>
+  links
+    .map((link) => ({ link, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ link }) => link);
+
+/** Reduce the list of links to just the top three. */
+const pickTopThree = (links) => links.slice(0, 3);
+
+/** Active rules, in order. */
+const rules = [
+  removeThrottledLinks,
+  removeLinkBacks,
+  randomizeOrder,
+  pickTopThree,
+];
+
+/** Apply the rules to the list of links. */
+const applyRules = async (allLinks, host) => {
+  const throttles = await getThrottles();
+
+  const params = {
+    host,
+    throttles,
+  };
+
+  return rules.reduce((links, rule) => {
+    const newLinks = rule(links, params);
+    return newLinks;
+  }, allLinks);
+};
+
+exports.applyRules = applyRules;

--- a/src/shared/throttles.js
+++ b/src/shared/throttles.js
@@ -1,0 +1,46 @@
+const arc = require("@architect/functions");
+const throttleDefs = require("./throttles.json");
+
+/** Retrieve throttles. */
+exports.getThrottles = async () => {
+  try {
+    const throttles = [...throttleDefs];
+
+    const day = new Date().toISOString().split("T")[0].toString();
+    const dynamo = await arc.tables();
+
+    const promises = [];
+
+    // Check each throttle to see if we've reached the limit.
+    // Add current stats to each throttle object.
+    throttles.forEach(async (throttle) => {
+      const name = throttle.name;
+
+      // If the throttle is already set to zero, we don't need to check DynamoDB.
+      if (throttle.limit === 0) {
+        throttle.count = 0;
+        throttle.exceeded = true;
+      } else {
+        const promise = dynamo.throttleclicks
+          .get({ name, day })
+          .then((response) => {
+            const count = response?.hits || 0;
+            throttle.count = count;
+            throttle.exceeded = count >= throttle.limit;
+            console.log(
+              `Throttle for ${name} on ${day} is at ${count}/${throttle.limit}.`
+            );
+          });
+
+        promises.push(promise);
+      }
+    });
+
+    await Promise.all(promises);
+
+    return throttles;
+  } catch (e) {
+    console.log("Error retrieving throttles.", e);
+    return [];
+  }
+};

--- a/src/shared/url.js
+++ b/src/shared/url.js
@@ -1,0 +1,123 @@
+/**
+ * url.js
+ * A collection of functions for comparing URLs.
+ * We'll be doing a lot of that when targetting links to send to the widget.
+ */
+
+const { URL } = require("url");
+
+/**
+ * Get a URL object from a string, if possible.
+ * @param {string} input A string representation of the URL.
+ * @returns {(URL|undefined)} A URL object, or undefined if parsing fails.
+ */
+const parse = (input) => {
+  try {
+    return input ? new URL(input) : undefined;
+  } catch (e) {
+    console.log("Could not parse URL", input);
+    return undefined;
+  }
+};
+
+/**
+ * Prepare the URL's hostname for comparisons.
+ * Removes things like "www.", etc.
+ * @param {URL} pUrl A URL object.
+ * @returns {string} A string representation of the URL's normalized hostname.
+ */
+const normalizeHost = (pUrl) => {
+  return pUrl.hostname.replace(/^www\./, "");
+};
+
+/**
+ * See if two URLs have matching hostnames.
+ * @param {URL} pUrl1 A URL object for the first URL.
+ * @param {URL} pUrl2 A URL object for the second URL.
+ * @returns {boolean}
+ */
+const compareHosts = (pUrl1, pUrl2) => {
+  return normalizeHost(pUrl1) === normalizeHost(pUrl2);
+};
+
+/**
+ * Prepare the URL's pathname for comparisons.
+ * Removes things like training slashes, etc.
+ * @param {URL} pUrl A URL object.
+ * @returns {string} A string representation of the URL's normalized pathname.
+ */
+const normalizePath = (pUrl) => {
+  return pUrl.pathname.replace(/\/$/, "");
+};
+
+/**
+ * See if two URLs have matching pathnames.
+ * @param {URL} pUrl1 A URL object for the first URL.
+ * @param {URL} pUrl2 A URL object for the second URL.
+ * @returns {boolean}
+ */
+const comparePaths = (pUrl1, pUrl2) => {
+  return normalizePath(pUrl1) === normalizePath(pUrl2);
+};
+
+const compare = (pUrl1, pUrl2) => {
+  return compareHosts(pUrl1, pUrl2) && comparePaths(pUrl1, pUrl2);
+};
+
+/**
+ * Check if two URLs match.
+ * @param {string} url1 A string representation of the first URL.
+ * @param {string} url2 A string representation of the second URL.
+ * @returns {boolean}
+ */
+const match = (url1, url2) => {
+  const pUrl1 = parse(url1);
+  const pUrl2 = parse(url2);
+
+  return pUrl1 && pUrl2 ? compare(pUrl1, pUrl2) : false;
+};
+
+/**
+ * Check if hostnames for two URLs match.
+ * @param {string} url1 A string representation of the first URL.
+ * @param {string} url2 A string representation of the second URL.
+ * @returns {boolean}
+ */
+const matchHosts = (url1, url2) => {
+  const pUrl1 = parse(url1);
+  const pUrl2 = parse(url2);
+
+  return pUrl1 && pUrl2 ? compareHosts(pUrl1, pUrl2) : false;
+};
+
+/**
+ * Check if paths for two URLs match.
+ * @param {string} url1 A string representation of the first URL.
+ * @param {string} url2 A string representation of the second URL.
+ * @returns {boolean}
+ */
+const matchPaths = (url1, url2) => {
+  const pUrl1 = parse(url1);
+  const pUrl2 = parse(url2);
+
+  return pUrl1 && pUrl2 ? comparePaths(pUrl1, pUrl2) : false;
+};
+
+/**
+ * Checks if a URL is included in a list of other URLs.
+ * @param {Array} urls An array of URL strings.
+ * @param {string} queryUrl A string representation of the URL to check.
+ * @returns {boolean}
+ */
+const findMatch = (urls, queryUrl) => {
+  const pQueryUrl = parse(queryUrl);
+  const pUrls = urls.map((u) => parse(u)).filter((pU) => pU !== undefined);
+
+  return pQueryUrl ? pUrls.some((pUrl) => compare(pUrl, pQueryUrl)) : false;
+};
+
+exports.parse = parse;
+exports.match = match;
+exports.matchHosts = matchHosts;
+exports.matchPaths = matchPaths;
+exports.findMatch = findMatch;

--- a/tests/http-test.js
+++ b/tests/http-test.js
@@ -26,19 +26,20 @@ test("get /benefits", async (t) => {
 /**
  * Ensure we don't deliver a link back to the same host.
  */
-test("get /benefits?host=CALFRESH", async (t) => {
+test("get /benefits?host=https://www.getcalfresh.org/s/ODIwidget", async (t) => {
   t.plan(10);
 
   // Repeat the test five times.
   for (i = 0; i < 5; i++) {
     let result = await tiny.get({
-      url: targetServer + "/benefits?host=CALFRESH",
+      url:
+        targetServer + "/benefits?host=https://www.getcalfresh.org/s/ODIwidget",
     });
 
     t.ok(result, "got 200 response");
 
     let links = JSON.parse(result.body).links;
-    let hostLinksFound = links.some((link) => link.key === "CALFRESH");
+    let hostLinksFound = links.some((link) => link.id === "CALFRESH");
 
     if (hostLinksFound) {
       t.fail("served link back to same host");


### PR DESCRIPTION
This is a big PR. Here's what's happening here.

* There's a new `src/shared/hosts.json` file with information about each placement partner/host.
* There's a new `src/shared/rules.js` file that orchestrates how links are chosen for the widget.
* Each target link in `src/shared/links.json` now holds information about the analytics engine on the target site.
* Each target link is now formatted for delivery with that analytics engine in mind. We can add URL query parameters to the link, like `utm_source` for sites that have Google Analytics.
* There's a new `src/shared/url.js` file with utilities for comparing URLs. We do that a lot on this service.
* There are changes to the behavior of the `host` URL query parameter, corresponding to cagov/benefits-recommendation-widget-front#6.
* A lot of code has been reorganized around the above changes, with several new files in `src/shared`.

We need these changes to ensure we can better target links and support analytics activities going forward.